### PR TITLE
Use gh command

### DIFF
--- a/.github/workflows/notion-task-linker.yaml
+++ b/.github/workflows/notion-task-linker.yaml
@@ -21,12 +21,10 @@ jobs:
             echo "notion_task=$notion_task" >> $GITHUB_OUTPUT
           fi
 
-      - uses: tzkhan/pr-update-action@bbd4c9395df8a9c4ef075b8b7fe29f2ca76cdca9
+      - name: update PR description
         if: steps.check-branch.outputs.match == 'true'
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          head-branch-regex: '.*' # not used
-          body-update-action: prefix
-          body-template: |
-            Notion Task: https://www.notion.so/${{ inputs.workspace }}/${{ steps.check-branch.outputs.notion_task }}
-            ---
+        run: |
+          DESCRIPTION=$(gh pr view ${{ github.event.pull_request.number }} --json body --jq .body)
+          gh pr edit ${{ github.event.pull_request.number }} --body  "Notion Task: https://www.notion.so/${{ inputs.workspace }}/${{ steps.check-branch.outputs.notion_task }}
+          ---
+          ${DESCRIPTION}"

--- a/.github/workflows/notion-task-linker.yaml
+++ b/.github/workflows/notion-task-linker.yaml
@@ -12,6 +12,8 @@ jobs:
     name: Link Notion Task
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4.1.1
+
       - name: Check Branch
         id: check-branch
         run: |

--- a/.github/workflows/notion-task-linker.yaml
+++ b/.github/workflows/notion-task-linker.yaml
@@ -23,6 +23,8 @@ jobs:
 
       - name: update PR description
         if: steps.check-branch.outputs.match == 'true'
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           DESCRIPTION=$(gh pr view ${{ github.event.pull_request.number }} --json body --jq .body)
           gh pr edit ${{ github.event.pull_request.number }} --body  "Notion Task: https://www.notion.so/${{ inputs.workspace }}/${{ steps.check-branch.outputs.notion_task }}


### PR DESCRIPTION
# What

Replaces actions using Node 16.

# Why
Forced switch to Node 20 on 2024-5-13, but [tzkhan/pr-update-action](https://github.com/tzkhan/pr-update-action) is not updated.
So, use Github CLI instead.
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/


# Note
e.g.
![スクリーンショット 2024-03-29 10 00 24](https://github.com/kauche/github-actions-notion-task-linker-workflow/assets/7904748/5eb8dcd7-ee53-451f-bfe6-62023bfe1403)
